### PR TITLE
add textAlign to be processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,15 @@ localizing styles happens on the key of the attibute, or its value. in LTR confi
   transform: skew
 }
 ```
+5. textAlign
 
+  `text-align` values' `start` and `end` are supported in all browers but not in IE11+ and Edge. Therefore, this transform was added.
+```
+{
+  textAlign: 'start'
+  textAlign: 'end'
+}
+```
 ### Localed Keys
 
 1. margins and paddings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-inline-styler-processor-rtl",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "React Inline Styler RTL Processors.",
   "main": "./distribution/index.js",
   "author": "Ahmad Bamieh",

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ const attributeValueReplacementFactory = (isRTL) => {
 
   return (attrubuteKey, attrubuteValue) => {
     switch (attrubuteKey) {
-      // case 'textAlign':
+      case 'textAlign':
       case 'float':
       case 'transformOrigin':
         return startEndReplacer(attrubuteValue, leftRightReplacements);

--- a/test/fixture/valueTransformations.js
+++ b/test/fixture/valueTransformations.js
@@ -40,5 +40,19 @@ const transformOrigin = {
     expectedLTR: 'right'
   }]
 }
+const textAlign = {
+  describe: 'textAlign',
+  cases: [{
+    input: 'textAlign',
+    value: 'start',
+    expectedRTL: 'right',
+    expectedLTR: 'left'
+  }, {
+    input: 'textAlign',
+    value: 'end',
+    expectedRTL: 'left',
+    expectedLTR: 'right'
+  }]
+}
 
-export default [transformOrigin, direction, float]
+export default [transformOrigin, direction, float, textAlign]


### PR DESCRIPTION
text-align: 'start'/'end' are not supported in IE11 and Edge so it has to be processed to left and right to support those browsers.